### PR TITLE
Switch to PDB files with "full" type information to enable WinDbg debugging

### DIFF
--- a/ImageClientCpp/ImageClientCpp.vcxproj
+++ b/ImageClientCpp/ImageClientCpp.vcxproj
@@ -58,7 +58,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -76,7 +75,6 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ImageSource/ImageSource.vcxproj
+++ b/ImageSource/ImageSource.vcxproj
@@ -55,7 +55,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>..\ImageSourceProxy</AdditionalIncludeDirectories>
@@ -88,7 +87,6 @@ echo Registering EXE...
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>..\ImageSourceProxy</AdditionalIncludeDirectories>

--- a/UnitTests/UnitTests.vcxproj
+++ b/UnitTests/UnitTests.vcxproj
@@ -50,7 +50,6 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
       <Command>$(TargetPath)</Command>
@@ -72,7 +71,6 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
       <Command>$(TargetPath)</Command>


### PR DESCRIPTION
Fixes #2. Remove `GenerateDebugInformation=true` settings to instead use the default settings, which are "Generate Debug Information optimized for sharing and publishing (/DEBUG:FULL)".